### PR TITLE
Add `forward` method to `LinkAsTorchModel`

### DIFF
--- a/chainer_pytorch_migration/parameter.py
+++ b/chainer_pytorch_migration/parameter.py
@@ -1,4 +1,5 @@
 import chainer_pytorch_migration as cpm
+import torch
 from torch import nn
 
 
@@ -21,7 +22,13 @@ class LinkAsTorchModel(nn.Module):
         self.link = link
 
     def forward(self, *input):
-        return self.link.forward(*input)
+        # The computation graph should be done in Chainer.
+        # Forward converts the input tensors to numpy/cupy arrays
+        # as accepted by Chainer.
+        # The return value should be a tensor as well.
+        input = [cpm.tensor.asarray(x) if isinstance(x, torch.Tensor)
+                 else x for x in input]
+        return cpm.tensor.astensor(self.link.forward(*input).array)
 
 
 class ChainerParameter(nn.Parameter):

--- a/chainer_pytorch_migration/parameter.py
+++ b/chainer_pytorch_migration/parameter.py
@@ -1,5 +1,4 @@
 import chainer_pytorch_migration as cpm
-
 from torch import nn
 
 
@@ -19,6 +18,10 @@ class LinkAsTorchModel(nn.Module):
         super(LinkAsTorchModel, self).__init__()
         for n, p in sorted(link.namedparams()):
             self.__setattr__(n, ChainerParameter(p))
+        self.link = link
+
+    def forward(self, *input):
+        return self.link.forward(*input)
 
 
 class ChainerParameter(nn.Parameter):


### PR DESCRIPTION
This allows trainer abstractions to be used with wrapped chainer models

When a chainer model is made accessible from pytorch, the `forward` method must be explicitly called from the chainer model itself as it doesn't exist in the pytorch wrapper. This allows to call `forward` from the wrapped model too.

The use case is to allow ignite to use the model in this manner.