### PR TITLE
Add custom collate functions for the `DataLoader`

### DIFF
--- a/chainer_pytorch_migration/ignite/__init__.py
+++ b/chainer_pytorch_migration/ignite/__init__.py
@@ -1,1 +1,2 @@
 from .extensions import add_trainer_extension, load_chainer_snapshot  # NOQA
+from .collate import collate_to_array  # NOQA

--- a/chainer_pytorch_migration/ignite/collate.py
+++ b/chainer_pytorch_migration/ignite/collate.py
@@ -1,0 +1,8 @@
+import torch
+
+from chainer_pytorch_migration import tensor
+
+
+def collate_to_array(batch):
+    data = torch.utils.data._utils.collate.default_collate(batch)
+    return [tensor.asarray(x) for x in data]

--- a/tests/test_collate.py
+++ b/tests/test_collate.py
@@ -1,0 +1,20 @@
+import numpy
+import torch
+import pytest
+
+import chainer_pytorch_migration.ignite as cpm_ignite
+
+
+@pytest.mark.parametrize(
+    'data, batch_size',
+    [([], 1), (list(range(10)), 1), (list(range(100)), 10)])
+def test_collate(data, batch_size):
+    collate = cpm_ignite.collate_to_array
+    dl = torch.utils.data.DataLoader(
+        data, collate_fn=collate, batch_size=batch_size)
+    for i, x in enumerate(dl):
+        for e in x:
+            assert isinstance(e, numpy.ndarray)
+        expected = [
+            numpy.array(e) for e in data[i * batch_size:(i + 1) * batch_size]]
+        numpy.testing.assert_array_equal(x, expected)


### PR DESCRIPTION
When using DataLoaders to feed wrapped chainer models in ignite, there is the need for the data to be converted to the current device array in chainer as all the computation graph must be done in chainer.