### PR TITLE
Fix epoch calculation when restoring snapshot in ignite

### DIFF
--- a/chainer_pytorch_migration/ignite/__init__.py
+++ b/chainer_pytorch_migration/ignite/__init__.py
@@ -1,2 +1,16 @@
+import ignite
+
 from .extensions import add_trainer_extension, load_chainer_snapshot  # NOQA
 from .collate import collate_to_array  # NOQA
+
+
+def _get_version(version):
+    # We compare up to the minor version (first two digits).
+    # This is because it is highly unlikely that these numbers
+    # will contain other character than digits.
+    return [int(x) for x in version.split('.')[:2]]
+
+
+if _get_version(ignite.__version__) < _get_version('0.3.0'):
+    raise ImportError('Ignite version found {}. '
+                      'Required is >=0.3.0'.format(ignite.__version__))

--- a/chainer_pytorch_migration/ignite/__init__.py
+++ b/chainer_pytorch_migration/ignite/__init__.py
@@ -1,3 +1,5 @@
+import re
+
 import ignite
 
 from .extensions import add_trainer_extension, load_chainer_snapshot  # NOQA
@@ -8,7 +10,16 @@ def _get_version(version):
     # We compare up to the minor version (first two digits).
     # This is because it is highly unlikely that these numbers
     # will contain other character than digits.
-    return [int(x) for x in version.split('.')[:2]]
+
+    # Ignite versioning system is not explicitly documented.
+    # However, it seems to be using semver, so the
+    # major and minor ids can be only integers.
+    # Some examples of versions are:
+    # 0.1.0, 0.1.1, 0.3.0.dev20191007, 0.3.0.
+    version_regexp = r'^[0-9]+\.[0-9]+\.[0-9]+(\.[0-9a-zA-Z]+)?$'
+    if re.search(version_regexp, version):
+        return [int(x) for x in version.split('.')[:2]]
+    raise ValueError('Invalid version format')
 
 
 if _get_version(ignite.__version__) < _get_version('0.3.0'):

--- a/chainer_pytorch_migration/ignite/extensions.py
+++ b/chainer_pytorch_migration/ignite/extensions.py
@@ -171,10 +171,11 @@ class ExtensionUpdaterAdapter(object):
 
         if isinstance(serializer, chainer.serializer.Serializer):
             state['iteration'] = self.engine.state.iteration
-            state['epoch'] = self.engine.state.epoch
+            state['epoch_length'] = self.engine.state.epoch_length
         elif isinstance(serializer, chainer.serializer.Deserializer):
             self.engine.state.iteration = state['iteration']
-            self.engine.state.epoch = state['epoch']
+            self.engine.state.epoch = (state['iteration']
+                                       // state['epoch_length'])
 
 
 class ExtensionTrainerAdapter(object):


### PR DESCRIPTION
Closes #12 
Epoch is increased in ignite engine state after the first iteration, causing issues when restoring the snapshot.
ignite calculates the epoch internally when restoring the status using just the iteration count and the epoch size. This PR mimics that