### PR TITLE
Better error message for uninitialized parameters in LinkAsTorchModel

### DIFF
--- a/chainer_pytorch_migration/parameter.py
+++ b/chainer_pytorch_migration/parameter.py
@@ -17,6 +17,16 @@ class LinkAsTorchModel(nn.Module):
 
     def __init__(self, link):
         super(LinkAsTorchModel, self).__init__()
+        uninitialized_params = [
+            n for n, p in sorted(link.namedparams()) if p.array is None]
+        if uninitialized_params:
+            raise RuntimeError(
+                'Link with uninitialized parameters cannot be wrapped with '
+                'LinkAsTorchModel. '
+                'Please initialize parameters before wrapping, by feeding a '
+                'dummy batch to the Chainer model, for example. '
+                'Uninitialized params: [{}]'.format(
+                    ', '.join(repr(n) for n in uninitialized_params)))
         for n, p in sorted(link.namedparams()):
             self.__setattr__(n, ChainerParameter(p))
 


### PR DESCRIPTION
Provides a better error message, rather than `TypeError: array cannot be None`:

```
  File "/home/niboshi/.local/lib/python3.6/site-packages/chainer_pytorch_migration/parameter.py", line 29, in __init__                                             
    self.__setattr__(n, ChainerParameter(p))                                                                                                                                                                       
  File "/home/niboshi/.local/lib/python3.6/site-packages/chainer_pytorch_migration/parameter.py", line 48, in __new__                           
    return super().__new__(cls, cpm.astensor(param.array))                                                                                                                                 
  File "/home/niboshi/.local/lib/python3.6/site-packages/chainer_pytorch_migration/tensor.py", line 65, in astensor                                          
    raise TypeError('array cannot be None')
```

Now:
`
RuntimeError: Link with uninitialized parameters cannot be wrapped with LinkAsTorchModel. Please initialize parameters before wrapping, by feeding a dummy batch to the Chainer model, for example. Uninitialized params: ['/model/net/extractor/conv1_1/conv/W']
`