### PR TITLE
Fix backprop of `LinkAsTorchModel`

### DIFF
--- a/chainer_pytorch_migration/__init__.py
+++ b/chainer_pytorch_migration/__init__.py
@@ -2,5 +2,5 @@ from . import links
 from .allocator import use_mempool_in_cupy_malloc, use_torch_in_cupy_malloc
 from .datasets import TransformDataset
 from .links import TorchModule
-from .parameter import ChainerParameter, LinkAsTorchModel
+from .parameter import ChainerParameter, LinkAsTorchModel, Optimizer
 from .tensor import asarray, astensor, to_numpy_dtype

--- a/chainer_pytorch_migration/parameter.py
+++ b/chainer_pytorch_migration/parameter.py
@@ -1,4 +1,5 @@
 import chainer_pytorch_migration as cpm
+import torch
 from torch import nn
 
 
@@ -21,7 +22,13 @@ class LinkAsTorchModel(nn.Module):
         self.link = link
 
     def forward(self, *input):
-        return self.link.forward(*input)
+        # The computation graph should be done in Chainer.
+        # Forward converts the input tensors to numpy/cupy arrays
+        # as accepted by Chainer.
+        # The return value should be a tensor as well.
+        input = [cpm.tensor.asarray(x) if isinstance(x, torch.Tensor)
+                 else x for x in input]
+        return cpm.tensor.astensor(self.link.forward(*input).array)
 
 
 class ChainerParameter(nn.Parameter):

--- a/chainer_pytorch_migration/parameter.py
+++ b/chainer_pytorch_migration/parameter.py
@@ -74,12 +74,11 @@ class Optimizer(torch.optim.Optimizer):
         return getattr(self._base_optimizer, name)
 
     def step(self, closure=None):
-        assert closure is None
         for param_group in self._base_optimizer.param_groups:
             for param in param_group['params']:
                 assert isinstance(param, ChainerParameter)
                 param.grad.copy_(torch.tensor(param._param.grad))
-        self._base_optimizer.step()
+        self._base_optimizer.step(closure)
 
     def zero_grad(self):
         self._base_optimizer.zero_grad()

--- a/chainer_pytorch_migration/parameter.py
+++ b/chainer_pytorch_migration/parameter.py
@@ -1,5 +1,4 @@
 import chainer_pytorch_migration as cpm
-
 from torch import nn
 
 
@@ -19,6 +18,10 @@ class LinkAsTorchModel(nn.Module):
         super(LinkAsTorchModel, self).__init__()
         for n, p in sorted(link.namedparams()):
             self.__setattr__(n, ChainerParameter(p))
+        self.link = link
+
+    def forward(self, *input):
+        return self.link.forward(*input)
 
 
 class ChainerParameter(nn.Parameter):

--- a/chainer_pytorch_migration/parameter.py
+++ b/chainer_pytorch_migration/parameter.py
@@ -77,7 +77,7 @@ class Optimizer(torch.optim.Optimizer):
         for param_group in self._base_optimizer.param_groups:
             for param in param_group['params']:
                 assert isinstance(param, ChainerParameter)
-                param.grad.copy_(torch.tensor(param._param.grad))
+                param.grad.copy_(cpm.astensor(param._param.grad))
         self._base_optimizer.step(closure)
 
     def zero_grad(self):

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -132,7 +132,7 @@ def test_link_as_torch_model_nested():
             self.constant = None
         def set_constant(self, constant):
             self.constant = constant
-        def step(self):
+        def step(self, closure=None):
             for group in self.param_groups:
                 for param in group['params']:
                     param.data[...] = self.constant

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -73,7 +73,7 @@ def test_chainer_parameter_grad_setter(shape):
     numpy.testing.assert_array_equal(grad, torch_param.grad)
 
 
-def test_to_chainer_parameters():
+def test_link_as_torch_model():
     # initialized parameter
     a_arr = numpy.ones((3,  2), 'float32')
     a_chainer_param = chainer.Parameter(a_arr)
@@ -101,7 +101,72 @@ def test_to_chainer_parameters():
     assert (a_chainer_param.array == numpy.arange(6).reshape((3, 2))).all()
 
 
-def test_to_chainer_parameters_uninitialized():
+def test_link_as_torch_model_nested():
+    dtype = numpy.float32
+
+    # l2: MyLink2 := p2 * l1(x)
+    #   - p2
+    #   - l1: MyLink1 := p1 * x
+    #     - p1
+    class MyLink1(chainer.Link):
+        def __init__(self):
+            super().__init__()
+            with self.init_scope():
+                self.p1 = chainer.Parameter(numpy.array([2], dtype))
+        def forward(self, x1):
+            return self.p1 * x1
+
+    class MyLink2(chainer.Chain):
+        def __init__(self):
+            super().__init__()
+            with self.init_scope():
+                self.p2 = chainer.Parameter(numpy.array([3], dtype))
+                self.l1 = MyLink1()
+        def forward(self, x2):
+            return self.p2 * self.l1(x2)
+
+    # Dummy optimizer that always writes the constant value 9.
+    class MyOptim(torch.optim.Optimizer):
+        def __init__(self, params):
+            super().__init__(params, {})
+        def step(self):
+            for group in self.param_groups:
+                for param in group['params']:
+                    param.data[...] = 9
+
+    link = MyLink2()
+    module = cpm.LinkAsTorchModel(link)
+    assert isinstance(module.p2, torch.nn.Parameter)
+    assert isinstance(module.l1, torch.nn.Module)
+    assert isinstance(module.l1.p1, torch.nn.Parameter)
+    assert len(list(module.parameters(recurse=False))) == 1
+    assert len(list(module.l1.parameters(recurse=False))) == 1
+    assert len(list(module.parameters(recurse=True))) == 2
+
+    optimizer = MyOptim(module.parameters())
+    x = numpy.array([4], dtype)
+
+    # Forward
+    y = module(x)
+    assert isinstance(y, torch.Tensor)
+    numpy.testing.assert_array_equal(y.detach().numpy(), [24])
+
+    # Backward
+    y.backward()
+
+    numpy.testing.assert_array_equal(module.l1.p1.grad.detach().numpy(), [12])
+    numpy.testing.assert_array_equal(module.p2.grad.detach().numpy(), [8])
+
+    # Optimizer step
+    optimizer.step()
+
+    numpy.testing.assert_array_equal(link.p2.array, [9])
+    numpy.testing.assert_array_equal(link.l1.p1.array, [9])
+    numpy.testing.assert_array_equal(module.p2.detach().numpy(), [9])
+    numpy.testing.assert_array_equal(module.l1.p1.detach().numpy(), [9])
+
+
+def test_link_as_torch_model_uninitialized():
     # Uninitialized parameters are not supported
     a_chainer_param = chainer.Parameter()
 
@@ -128,10 +193,10 @@ def test_state_dict():
 
     torched = cpm.LinkAsTorchModel(link)
     state_dict = torched.state_dict()
-    assert '/a' in state_dict
-    numpy.testing.assert_array_equal(a_arr, state_dict['/a'].detach())
-    assert '/b' in state_dict
-    numpy.testing.assert_array_equal(b_arr, state_dict['/b'].detach())
+    assert 'a' in state_dict
+    numpy.testing.assert_array_equal(a_arr, state_dict['a'].detach())
+    assert 'b' in state_dict
+    numpy.testing.assert_array_equal(b_arr, state_dict['b'].detach())
 
 
 def test_named_params():
@@ -148,7 +213,7 @@ def test_named_params():
 
     torched = cpm.LinkAsTorchModel(link)
     n_params = dict(torched.named_parameters())
-    assert '/a' in n_params
-    numpy.testing.assert_array_equal(a_arr, n_params['/a'].detach())
-    assert '/b' in n_params
-    numpy.testing.assert_array_equal(b_arr, n_params['/b'].detach())
+    assert 'a' in n_params
+    numpy.testing.assert_array_equal(a_arr, n_params['a'].detach())
+    assert 'b' in n_params
+    numpy.testing.assert_array_equal(b_arr, n_params['b'].detach())


### PR DESCRIPTION
Continuation after #6

Fixes `LinkAsTorchModel` so that it can backprop through the underlying Chainer model.