### PR TITLE
Rely on `__cuda_array_interface__` for tensor conversions

### DIFF
--- a/chainer_pytorch_migration/tensor.py
+++ b/chainer_pytorch_migration/tensor.py
@@ -46,7 +46,7 @@ def astensor(array):
         view are gone.
 
     Note:
-        aaIf the array has negative strides, a copy is made
+        If the array has negative strides, a copy is made
     """
     if array is None:
         raise TypeError('array cannot be None')


### PR DESCRIPTION
The bugs were already fixed in PyTorch, so do the conversions directly avoiding hacks.